### PR TITLE
Fix conflict with Bootstrap 3

### DIFF
--- a/css/bootstrap-modal.css
+++ b/css/bootstrap-modal.css
@@ -471,6 +471,7 @@
 
 .wp-block-frm-modal-content .modal-dialog {
 	margin-top: 30px;
+	transform: none !important;
 }
 
 body.admin-bar .wp-block-frm-modal-content .modal-dialog {
@@ -530,4 +531,8 @@ body.admin-bar .wp-block-frm-modal-content .modal-dialog {
 
 .wp-block-frm-modal-content .modal-body > div > *:first-child {
 	margin-top: 0;
+}
+
+.wp-block-frm-modal-content.show {
+	opacity: 1 !important;
 }

--- a/css/bootstrap-modal.css
+++ b/css/bootstrap-modal.css
@@ -516,8 +516,8 @@ body.admin-bar .wp-block-frm-modal-content .modal-dialog {
 
 .wp-block-frm-modal-content .frm_modal_header_no_title .close {
 	position: absolute;
-	right: 26px;
-	top: 26px;
+	right: 1.625rem;
+	top: 1.625rem;
 	z-index: 1000;
 }
 


### PR DESCRIPTION
Fixes #22 

Steps to replicate:
- Install Formidable Bootstrap Forms addon.
- Add a modal to a page (using shortcode or blocks)
- Save and view page, the modal doesn't show after clicking on the modal button.

The problem is Bootstrap 3 uses `opacity` for `.fade`, but Bootstrap 5 doesn't.
This PR also fixes the top margin of the modal, the Bootstrap 3 moves the modal up 25%.