### PR TITLE
Fix modal backdrop is missing when using modal shortcode

### DIFF
--- a/classes/frmBtsModApp.php
+++ b/classes/frmBtsModApp.php
@@ -283,7 +283,7 @@ class frmBtsModApp {
 				$title = empty( $form_atts['modal_title'] ) ? $form_atts['label'] : $form_atts['modal_title'];
 
 				$modal = '<div id="frm-modal-' . esc_attr( $i ) . '"';
-				$modal .= ' class="modal fade wp-block-frm-modal-content ' . esc_attr( $form_atts['modal_class'] ) . '" tabindex="-1" role="dialog"';
+				$modal .= ' class="modal fade frm-modal-sc wp-block-frm-modal-content ' . esc_attr( $form_atts['modal_class'] ) . '" tabindex="-1" role="dialog"';
 				$modal .= ' aria-labelledby="frmModalLabel-' . esc_attr( $i ) . '" aria-hidden="true">';
 				$modal .= '<div class="modal-dialog ' . esc_attr( $size ) . '">';
 				$modal .= '<div class="modal-content">';

--- a/css/bootstrap-modal.css
+++ b/css/bootstrap-modal.css
@@ -520,7 +520,7 @@ body.admin-bar .wp-block-frm-modal-content .modal-dialog {
 	z-index: 1000;
 }
 
-.wp-block-frm-modal-content.show ~ .modal-backdrop.show {
+.wp-block-frm-modal-content:not(.frm-modal-sc).show ~ .modal-backdrop.show {
 	opacity: 0 !important;
 }
 


### PR DESCRIPTION
Steps to replicate: Just create a modal using `[frmmodal-content]` shortcode: https://formidableforms.com/knowledgebase/bootstrap-modal/#kb-usage

**Before: The backdrop is missing**
<img width="1131" alt="Screen Shot 2023-06-19 at 15 41 10" src="https://github.com/Strategy11/formidable-modal/assets/19748318/f603ec40-2677-4290-b1cb-30ea22ce2fc2">

**After:**
<img width="1131" alt="Screen Shot 2023-06-19 at 15 41 49" src="https://github.com/Strategy11/formidable-modal/assets/19748318/0c45ccd0-3646-4d77-ae40-49e0444c836e">
