### PR TITLE
Prevent fatal error when lite is not active

### DIFF
--- a/classes/frmBtsModBlockController.php
+++ b/classes/frmBtsModBlockController.php
@@ -17,8 +17,14 @@ class frmBtsModBlockController {
 
 	/**
 	 * Init blocks.
+	 *
+	 * @return void
 	 */
 	public static function init_blocks() {
+		if ( ! class_exists( 'FrmAppHelper' ) ) {
+			return;
+		}
+
 		register_block_type(
 			frmBtsModApp::plugin_path() . '/blocks/frm-modal',
 			array(


### PR DESCRIPTION
> [23-Oct-2023 18:34:31 UTC] PHP Fatal error:  Uncaught Error: Class 'FrmAppHelper' not found in /var/www/src/wp-content/plugins/formidable-modal/classes/frmBtsModBlockController.php:25
> Stack trace:
> #0 /var/www/src/wp-includes/class-wp-hook.php(310): frmBtsModBlockController::init_blocks('')
> #1 /var/www/src/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters(NULL, Array)
> #2 /var/www/src/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
> #3 /var/www/src/wp-settings.php(632): do_action('init')
> #4 /var/www/wp-config.php(118): require_once('/var/www/src/wp...')
> #5 /var/www/src/wp-load.php(55): require_once('/var/www/wp-con...')
> #6 /var/www/src/wp-admin/admin.php(34): require_once('/var/www/src/wp...')
> #7 /var/www/src/wp-admin/plugins.php(10): require_once('/var/www/src/wp...')
> #8 {main}
>   thrown in /var/www/src/wp-content/plugins/formidable-modal/classes/frmBtsModBlockController.php on line 25
> [23-Oct-2023 18:34:34 UTC] PHP Notice:  Function add_shortcode was called <strong>incorrectly</strong>. Invalid shortcode name: [custom_one]. Do not use spaces or reserved characters: & / < > [ ] = Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 4.4.0.) in /var/www/src/wp-includes/functions.php on line 5905
> [23-Oct-2023 18:34:34 UTC] PHP Fatal error:  Uncaught Error: Class 'FrmAppHelper' not found in /var/www/src/wp-content/plugins/formidable-modal/classes/frmBtsModBlockController.php:25