### PR TITLE
Add modal block description

### DIFF
--- a/blocks-src/frm-modal/block.json
+++ b/blocks-src/frm-modal/block.json
@@ -6,7 +6,7 @@
   "title": "Formidable Modal",
   "category": "widgets",
   "icon": "smiley",
-  "description": "",
+  "description": "Display a modal",
   "supports": {
     "html": false,
     "defaultStylePicker": true,

--- a/blocks/frm-modal/block.json
+++ b/blocks/frm-modal/block.json
@@ -6,7 +6,7 @@
   "title": "Formidable Modal",
   "category": "widgets",
   "icon": "smiley",
-  "description": "",
+  "description": "Display a modal",
   "supports": {
     "html": false,
     "defaultStylePicker": true,


### PR DESCRIPTION
The description is missing. I added the same description as in the Lite block.